### PR TITLE
Use AES keysize from input

### DIFF
--- a/ios/RCTCrypto/lib/Aes.m
+++ b/ios/RCTCrypto/lib/Aes.m
@@ -19,7 +19,7 @@
                                           kCCAlgorithmAES128,
                                           kCCOptionPKCS7Padding,
                                           keyData.bytes,
-                                          kCCKeySizeAES128,
+                                          keyData.length,
                                           ivData.bytes,
                                           data.bytes, data.length,
                                           buffer.mutableBytes,


### PR DESCRIPTION
The AES module will fail to decrypt ciphertext when the key is longer than the 128bit key size used for AES-128.

There are then two options available:

1) Change the AES module to use any size key provided (the method this pull request uses)
2) Fail when the key is not 128 bit (would require making sure all users provide the correct key size).

As there is no harm to Option 1 (and [other](http://robnapier.net/aes-commoncrypto) projects use it), it makes sense to allow the use of other key sizes.

This pull request fixes both the encryption and decryption of messages between Common Crypto and the WebCrypto API. The result was nil from the decrypted string not being UTF-8 encoded (as the key was truncated the decrypted string was garbage data).

Closes #1 