### PR TITLE
Fix Podfile

### DIFF
--- a/react-native-simple-crypto.podspec
+++ b/react-native-simple-crypto.podspec
@@ -5,10 +5,10 @@ Pod::Spec.new do |s|
   s.name          = package_json["name"]
   s.version       = package_json["version"]
   s.summary       = package_json["description"]
-  s.author        = package["author"]
+  s.author        = package_json["author"]
   s.license       = package_json["license"]
   s.requires_arc  = true
-  s.homepage      = package["homepage"]
+  s.homepage      = package_json["homepage"]
   s.source        = { :git => "#{package_json["repository"]["url"]}" }
   s.platform      = :ios, '8.0'
   s.source_files  = "ios/**/*.{h,m}"


### PR DESCRIPTION
Podfile wrongly referenced `package` instead of `package_json`, so Cocoa Pods fails with an error:
```
Invalid `react-native-simple-crypto.podspec` file: undefined local variable or method `package' for Pod:Module
```
This fixes the problem. It works beautifully otherwise, even in RN 0.60.x.
Thanks!