### PR TITLE
Internal upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,21 +127,21 @@ const ivArrayBuffer = await RNSimpleCrypto.utils.randomBytes(16);
 console.log("randomBytes iv", ivArrayBuffer);
 
 const cipherTextArrayBuffer = await RNSimpleCrypto.AES.encrypt(
-  msgArrayBuffer,
+  messageArrayBuffer,
   keyArrayBuffer,
   ivArrayBuffer
 );
 console.log("AES encrypt", cipherTextArrayBuffer);
 
-const messageArrayBuffer = await RNSimpleCrypto.AES.decrypt(
+const decryptedArrayBuffer = await RNSimpleCrypto.AES.decrypt(
   cipherTextArrayBuffer,
   keyArrayBuffer,
   ivArrayBuffer
 );
-const message = RNSimpleCrypto.utils.convertArrayBufferToUtf8(
-  messageArrayBuffer
+const decrypted = RNSimpleCrypto.utils.convertArrayBufferToUtf8(
+ decryptedArrayBuffer
 );
-console.log("AES decrypt", message);
+console.log("AES decrypt", decrypted);
 
 // -- HMAC ------------------------------------------------------------ //
 

--- a/android/src/main/java/org/walletconnect/crypto/RCTAes.java
+++ b/android/src/main/java/org/walletconnect/crypto/RCTAes.java
@@ -142,7 +142,7 @@ public class RCTAes extends ReactContextBaseJavaModule {
         Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
         cipher.init(Cipher.DECRYPT_MODE, secretKey, hexIv == null ? emptyIvSpec : new IvParameterSpec(Hex.decode(hexIv)));
         byte[] decrypted = cipher.doFinal(Base64.decode(ciphertext, Base64.NO_WRAP));
-        return new String(decrypted, "UTF-8");
+        return Base64.encodeToString(decrypted, Base64.NO_WRAP)
     }
 
 }

--- a/android/src/main/java/org/walletconnect/crypto/RCTAes.java
+++ b/android/src/main/java/org/walletconnect/crypto/RCTAes.java
@@ -61,9 +61,9 @@ public class RCTAes extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void encrypt(String data, String keyBase64, String ivBase64, Promise promise) {
+    public void encrypt(String dataBase64, String keyBase64, String ivBase64, Promise promise) {
         try {
-            String result = encrypt(data, keyBase64, ivBase64);
+            String result = encrypt(dataBase64, keyBase64, ivBase64);
             promise.resolve(result);
         } catch (Exception e) {
             promise.reject("-1", e.getMessage());
@@ -116,8 +116,8 @@ public class RCTAes extends ReactContextBaseJavaModule {
 
     final static IvParameterSpec emptyIvSpec = new IvParameterSpec(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
 
-    private static String encrypt(String text, String hexKey, String hexIv) throws Exception {
-        if (text == null || text.length() == 0) {
+    private static String encrypt(String textBase64, String hexKey, String hexIv) throws Exception {
+        if (textBase64 == null || textBase64.length() == 0) {
             return null;
         }
 
@@ -126,7 +126,8 @@ public class RCTAes extends ReactContextBaseJavaModule {
 
         Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
         cipher.init(Cipher.ENCRYPT_MODE, secretKey, hexIv == null ? emptyIvSpec : new IvParameterSpec(Hex.decode(hexIv)));
-        byte[] encrypted = cipher.doFinal(text.getBytes("UTF-8"));
+        byte [] textBytes = Base64.getEncoder().decode(textBase64);
+        byte[] encrypted = cipher.doFinal(textBytes);
         return Base64.encodeToString(encrypted, Base64.NO_WRAP);
     }
 

--- a/index.js
+++ b/index.js
@@ -91,7 +91,6 @@ function randomBytes(length) {
 
 const AES = {
   encrypt: function(textArrayBuffer, keyArrayBuffer, ivArrayBuffer) {
-    // Input might not be UTF8 encodable
     const textBase64 = convertArrayBufferToBase64(textArrayBuffer);
     const keyHex = convertArrayBufferToHex(keyArrayBuffer);
     const ivHex = convertArrayBufferToHex(ivArrayBuffer);

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ const AES = {
     return new Promise((resolve, reject) => {
       NativeModules.Aes.decrypt(cipherTextBase64, keyHex, ivHex)
         .then(textString => {
-          const result = convertUtf8ToArrayBuffer(textString);
+          const result = convertBase64ToArrayBuffer(textString);
           resolve(result);
         })
         .catch(error => reject(error));

--- a/index.js
+++ b/index.js
@@ -91,11 +91,12 @@ function randomBytes(length) {
 
 const AES = {
   encrypt: function(textArrayBuffer, keyArrayBuffer, ivArrayBuffer) {
-    const textString = convertArrayBufferToUtf8(textArrayBuffer);
+    // Input might not be UTF8 encodable
+    const textBase64 = convertArrayBufferToBase64(textArrayBuffer);
     const keyHex = convertArrayBufferToHex(keyArrayBuffer);
     const ivHex = convertArrayBufferToHex(ivArrayBuffer);
     return new Promise((resolve, reject) => {
-      NativeModules.Aes.encrypt(textString, keyHex, ivHex)
+      NativeModules.Aes.encrypt(textBase64, keyHex, ivHex)
         .then(cipherTextBase64 => {
           const result = convertBase64ToArrayBuffer(cipherTextBase64);
           resolve(result);

--- a/ios/RCTCrypto/RCTAes.m
+++ b/ios/RCTCrypto/RCTAes.m
@@ -5,11 +5,11 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(encrypt:(NSString *)data key:(NSString *)key iv:(NSString *)iv
+RCT_EXPORT_METHOD(encrypt:(NSString *)dataBase64 key:(NSString *)key iv:(NSString *)iv
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSError *error = nil;
-    NSString *base64 = [Aes encrypt:data key:key iv:iv];
+    NSString *base64 = [Aes encrypt:dataBase64 key:key iv:iv];
     if (base64 == nil) {
         reject(@"encrypt_fail", @"Encrypt error", error);
     } else {

--- a/ios/RCTCrypto/lib/Aes.h
+++ b/ios/RCTCrypto/lib/Aes.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
 @interface Aes : NSObject
-+ (NSString *) encrypt: (NSString *)clearText  key: (NSString *)key iv: (NSString *)iv;
++ (NSString *) encrypt: (NSString *)clearText64  key: (NSString *)key iv: (NSString *)iv;
 + (NSString *) decrypt: (NSString *)cipherText key: (NSString *)key iv: (NSString *)iv;
 @end

--- a/ios/RCTCrypto/lib/Aes.m
+++ b/ios/RCTCrypto/lib/Aes.m
@@ -42,7 +42,7 @@
 
 + (NSString *) decrypt: (NSString *)cipherText key: (NSString *)key iv: (NSString *)iv {
     NSData *result = [self AES128CBC:@"decrypt" data:[[NSData alloc] initWithBase64EncodedString:cipherText options:0] key:key iv:iv];
-    return [[NSString alloc] initWithData:result encoding:NSUTF8StringEncoding];
+    return [result base64EncodedStringWithOptions:0];
 }
 
 @end

--- a/ios/RCTCrypto/lib/Aes.m
+++ b/ios/RCTCrypto/lib/Aes.m
@@ -34,8 +34,9 @@
     return nil;
 }
 
-+ (NSString *) encrypt: (NSString *)clearText key: (NSString *)key iv: (NSString *)iv {
-    NSData *result = [self AES128CBC:@"encrypt" data:[clearText dataUsingEncoding:NSUTF8StringEncoding] key:key iv:iv];
++ (NSString *) encrypt: (NSString *)clearText64 key: (NSString *)key iv: (NSString *)iv {
+    NSData* clearData = [[NSData alloc] initWithBase64EncodedString:base64Encoded options:0];
+    NSData *result = [self AES128CBC:@"encrypt" data:clearData key:key iv:iv];
     return [result base64EncodedStringWithOptions:0];
 }
 

--- a/ios/RCTCrypto/lib/Aes.m
+++ b/ios/RCTCrypto/lib/Aes.m
@@ -35,7 +35,7 @@
 }
 
 + (NSString *) encrypt: (NSString *)clearText64 key: (NSString *)key iv: (NSString *)iv {
-    NSData* clearData = [[NSData alloc] initWithBase64EncodedString:base64Encoded options:0];
+    NSData* clearData = [[NSData alloc] initWithBase64EncodedString:clearText64 options:0];
     NSData *result = [self AES128CBC:@"encrypt" data:clearData key:key iv:iv];
     return [result base64EncodedStringWithOptions:0];
 }

--- a/ios/RCTCrypto/lib/Shared.m
+++ b/ios/RCTCrypto/lib/Shared.m
@@ -7,10 +7,13 @@
 @implementation Shared
 
 + (NSString *) toHex:(NSData *)nsdata {
-    NSString * hexStr = [NSString stringWithFormat:@"%@", nsdata];
-    for(NSString * toRemove in [NSArray arrayWithObjects:@"<", @">", @" ", nil])
-        hexStr = [hexStr stringByReplacingOccurrencesOfString:toRemove withString:@""];
-    return hexStr;
+    // Copied from: https://riptutorial.com/ios/example/18979/converting-nsdata-to-hex-string
+    const unsigned char *bytes = (const unsigned char *)nsdata.bytes;
+    NSMutableString *hex = [NSMutableString new];
+    for (NSInteger i = 0; i < nsdata.length; i++) {
+        [hex appendFormat:@"%02x", bytes[i]];
+    }
+    return [hex copy];
 }
 
 + (NSData *) fromHex: (NSString *)string {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-simple-crypto",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "A simpler React-Native crypto library",
   "main": "index.js",
   "author": "Pedro Gomes <pedro@pedrouid.com>",


### PR DESCRIPTION
Use base64 for internal representation instead of UTF8 so that we can represent any types of data, not just UTF8 data. (for example files)