### PR TITLE
URGENT FIX: SHA hashing broken on Android for UTF8

### DIFF
--- a/android/src/main/java/com/pedrouid/crypto/RCTSha.java
+++ b/android/src/main/java/com/pedrouid/crypto/RCTSha.java
@@ -86,7 +86,7 @@ public class RCTSha extends ReactContextBaseJavaModule {
     @ReactMethod
     public void shaUtf8(String data, String algorithm, Promise promise) throws Exception {
         try {
-            byte[] digest = data.getBytes();
+            byte[] digest = this.sha(data.getBytes(), algorithm);
             promise.resolve(Base64.encodeToString(digest, Base64.DEFAULT));
         } catch (Exception e) {
             promise.reject("-1", e.getMessage());


### PR DESCRIPTION
This is my fault. I just noticed an urgent breaking bug in my previous merged PR. I broke SHA hashing on Android when passing in a string.

I verified that the iOS code is correct but a second set of eyes on both would be great.

**I recommend that you contact npm to unpublish the previous release**

I am also looking into how to write unit tests for the native code