### PR TITLE
Android: Change SHA hash of a string to match iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ Testing [repository](https://github.com/ghbutton/react-native-simple-crypto-test
 ```javascript
 import RNSimpleCrypto from "react-native-simple-crypto";
 
+const toHex = RNSimpleCrypto.utils.convertArrayBufferToHex
+const toUtf8 = RNSimpleCrypto.utils.convertArrayBufferToUtf8
+
 // -- AES ------------------------------------------------------------- //
 const message = "data to encrypt";
 const messageArrayBuffer = RNSimpleCrypto.utils.convertUtf8ToArrayBuffer(
@@ -125,37 +128,33 @@ const messageArrayBuffer = RNSimpleCrypto.utils.convertUtf8ToArrayBuffer(
 );
 
 const keyArrayBuffer = await RNSimpleCrypto.utils.randomBytes(32);
-console.log("randomBytes key", keyArrayBuffer);
+console.log("randomBytes key", toHex(keyArrayBuffer));
 
 const ivArrayBuffer = await RNSimpleCrypto.utils.randomBytes(16);
-console.log("randomBytes iv", ivArrayBuffer);
+console.log("randomBytes iv", toHex(ivArrayBuffer));
 
 const cipherTextArrayBuffer = await RNSimpleCrypto.AES.encrypt(
   messageArrayBuffer,
   keyArrayBuffer,
   ivArrayBuffer
 );
-console.log("AES encrypt", cipherTextArrayBuffer);
+console.log("AES encrypt", toHex(cipherTextArrayBuffer))
 
 const decryptedArrayBuffer = await RNSimpleCrypto.AES.decrypt(
   cipherTextArrayBuffer,
   keyArrayBuffer,
   ivArrayBuffer
 );
-const decrypted = RNSimpleCrypto.utils.convertArrayBufferToUtf8(
- decryptedArrayBuffer
-);
-console.log("AES decrypt", decrypted);
+console.log("AES decrypt", toUtf8(decryptedArrayBuffer));
+if (toUtf8(decryptedArrayBuffer) !== message) {
+  console.error('AES decrypt returned unexpected results')
+}
 
 // -- HMAC ------------------------------------------------------------ //
 
 const keyHmac = await RNSimpleCrypto.utils.randomBytes(32);
-const signatureArrayBuffer = await RNSimpleCrypto.HMAC.hmac256(message, keyHmac);
-
-const signatureHex = RNSimpleCrypto.utils.convertArrayBufferToHex(
-  signatureArrayBuffer
-);
-console.log("HMAC signature", signatureHex);
+const signatureArrayBuffer = await RNSimpleCrypto.HMAC.hmac256(messageArrayBuffer, keyHmac);
+console.log("HMAC signature", toHex(signatureArrayBuffer));
 
 // -- SHA ------------------------------------------------------------- //
 
@@ -168,18 +167,29 @@ console.log("SHA256 hash", sha256Hash);
 const sha512Hash = await RNSimpleCrypto.SHA.sha512("test");
 console.log("SHA512 hash", sha512Hash);
 
-const dataToHash = await RNSimpleCrypto.utils.randomBytes(64);
-const sha1ArrayBuffer = await RNSimpleCrypto.SHA.sha1(dataToHash);
-console.log('SHA256 hash bytes', sha1ArrayBuffer);
+const arrayBufferToHash = RNSimpleCrypto.utils.convertUtf8ToArrayBuffer("test");
+const sha1ArrayBuffer = await RNSimpleCrypto.SHA.sha1(arrayBufferToHash);
+console.log('SHA1 hash bytes', toHex(sha1ArrayBuffer));
+if (toHex(sha1ArrayBuffer) !== sha1Hash) {
+  console.error('SHA1 result mismatch!')
+}
 
-const sha256ArrayBuffer = await RNSimpleCrypto.SHA.sha256(dataToHash);
-console.log('SHA256 hash bytes', sha256ArrayBuffer);
+const sha256ArrayBuffer = await RNSimpleCrypto.SHA.sha256(arrayBufferToHash);
+console.log('SHA256 hash bytes', toHex(sha256ArrayBuffer));
+if (toHex(sha256ArrayBuffer) !== sha256Hash) {
+  console.error('SHA256 result mismatch!')
+}
 
+const sha512ArrayBuffer = await RNSimpleCrypto.SHA.sha512(arrayBufferToHash);
+console.log('SHA512 hash bytes', toHex(sha512ArrayBuffer));
+if (toHex(sha512ArrayBuffer) !== sha512Hash) {
+  console.error('SHA512 result mismatch!')
+}
 
 // -- PBKDF2 ---------------------------------------------------------- //
 
 const password = "secret password";
-const salt = RNSimpleCrypto.utils.randomBytes(8);
+const salt = "my-salt"
 const iterations = 4096;
 const keyInBytes = 32;
 const hash = "SHA1";
@@ -190,9 +200,23 @@ const passwordKey = await RNSimpleCrypto.PBKDF2.hash(
   keyInBytes,
   hash
 );
-console.log("PBKDF2 passwordKey", passwordKey);
+console.log("PBKDF2 passwordKey", toHex(passwordKey));
+
+const passwordKeyArrayBuffer = await RNSimpleCrypto.PBKDF2.hash(
+  RNSimpleCrypto.utils.convertUtf8ToArrayBuffer(password),
+  RNSimpleCrypto.utils.convertUtf8ToArrayBuffer(salt),
+  iterations,
+  keyInBytes,
+  hash
+);
+console.log("PBKDF2 passwordKey bytes", toHex(passwordKeyArrayBuffer));
+
+if (toHex(passwordKeyArrayBuffer) !== toHex(passwordKey)) {
+  console.error('PBKDF2 result mismatch!')
+}
+
 const password2 = messageArrayBuffer;
-const salt2 = RNSimpleCrypto.utils.randomBytes(8);
+const salt2 = await RNSimpleCrypto.utils.randomBytes(8);
 const iterations2 = 10000;
 const keyInBytes2 = 32;
 const hash2 = "SHA256";
@@ -204,7 +228,8 @@ const passwordKey2 = await RNSimpleCrypto.PBKDF2.hash(
   keyInBytes2,
   hash2
 );
-console.log("PBKDF2 passwordKey", passwordKey2);
+console.log("PBKDF2 passwordKey2", toHex(passwordKey2));
+
 
 // -- RSA ------------------------------------------------------------ //
 
@@ -238,6 +263,9 @@ const rsaDecryptedMessage = await RNSimpleCrypto.RSA.decrypt(
   rsaKeys.private
 );
 console.log("rsa Decrypt:", rsaDecryptedMessage);
+if (rsaDecryptedMessage !== message ) {
+  console.error('RSA decrypt returned unexpected result')
+}
 ```
 
 ## Forked Libraries

--- a/android/src/main/java/com/pedrouid/crypto/RCTSha.java
+++ b/android/src/main/java/com/pedrouid/crypto/RCTSha.java
@@ -87,7 +87,7 @@ public class RCTSha extends ReactContextBaseJavaModule {
     public void shaUtf8(String data, String algorithm, Promise promise) throws Exception {
         try {
             byte[] digest = this.sha(data.getBytes(), algorithm);
-            promise.resolve(Base64.encodeToString(digest, Base64.DEFAULT));
+            promise.resolve(Util.bytesToHex(digest));
         } catch (Exception e) {
             promise.reject("-1", e.getMessage());
         }


### PR DESCRIPTION
The iOS native functions for SHA hashing, **when the input is a string,** return a hex string. Android's native function returns a base64 string.  When the input is an `ArrayBuffer`, the return values match on both platforms (and don't need to be fixed).

Example:
```js
const sha256Hash = await RNSimpleCrypto.SHA.sha256("test");
console.log("SHA256 hash", sha256Hash);
// iOS: 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
// Android: n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg=
```

After this patch, both iOS and Android return the same hex string.